### PR TITLE
Fix #5

### DIFF
--- a/wsgiserver.py
+++ b/wsgiserver.py
@@ -31,12 +31,12 @@ https://www.python.org/dev/peps/pep-0333/
 import io
 import gc
 from micropython import const
-import wifi, socketpool
+import socketpool
+import wifi
 
 _BUFFER_SIZE = 32
 buffer = bytearray(_BUFFER_SIZE)
 def readline(socketin):
-    global buffer
     """
     Implement readline() for native wifi using recv_into
     """


### PR DESCRIPTION
Fix crashing on blank (or otherwise malformed) line.
```
_get_environ: need more than 0 values to unpack
```
Uses an internal custom `BadRequestError` exception.
Also try to reply with `400 Bad Request` in case the connection is not closed.